### PR TITLE
Fix compatibility with rubytest 0.5+

### DIFF
--- a/.index
+++ b/.index
@@ -10,7 +10,7 @@ copyrights:
   year: '2009'
   license: BSD-2-Clause
 requirements:
-- name: rubytest
+- name: rubytest-cli
 - name: ae
 - name: ansi
   version: 1.3+

--- a/Indexfile
+++ b/Indexfile
@@ -15,7 +15,7 @@ resources:
   bugs: http://github.com/rubyworks/lemon/issues
 
 requirements:
-  - rubytest
+  - rubytest-cli
   - ae
   - ansi 1.3+
   - detroit  (build)

--- a/lib/lemon/cli.rb
+++ b/lib/lemon/cli.rb
@@ -24,8 +24,8 @@ module Lemon
     case cmd
     when 't', 'test', 'run'
       require 'lemon'
-      require 'rubytest'
-      Test::Runner.cli(*ARGV)
+      require 'rubytest-cli'
+      Test::CLI.new(ARGV)
       #Lemon::CLI::Test.new.run(argv)
     when 'g', 'gen', 'generate', 'generator'
       Lemon::CLI::Generate.run(argv)


### PR DESCRIPTION
Since rubytest 0.5, `Test::Runner.cli` gets removed, which breaks the lemons command line utility:

```
lib/lemon/cli.rb:28:in `cli': undefined method `cli' for
Test::Runner:Class (NoMethodError)
```

As the CLI functionality was split off as `rubytest-cli`, let's depend on it instead and adapt to the new method name.

Since the original test folder is no longer present now with lemon 0.9+, I can at least verify that lemons runs successfully with rubytest 0.7.0
+ rubytest-cli 0.1.0 after this change.